### PR TITLE
Read AND write access to chasse_config for non-admin user

### DIFF
--- a/chasse.php
+++ b/chasse.php
@@ -214,7 +214,7 @@ function chasse_civicrm_alterAPIPermissions($entity, $action, &$params, &$permis
     }
 
     // Check 'chasse_config' is the *only* setting to "create" in the parameters for the api call before granting access.
-    if (! array_diff ( array_keys($params), array( 'chasse_config', 'check_permissions', 'prettyprint', 'version' ) ) ) {
+    if (array_diff ( array_keys($params), ['check_permissions', 'prettyprint', 'version'] ) === ['chasse_config'] ) {
       $permissions['setting']['create'] = $chasseAccessPermissions;
     }
 

--- a/chasse.php
+++ b/chasse.php
@@ -220,7 +220,7 @@ function chasse_civicrm_alterAPIPermissions($entity, $action, &$params, &$permis
 
   }
 
-  // Allow users witih 'edit message templates' to call:
+  // Allow users with 'edit message templates' to call:
   // - Chasse.getstats
   // - Chasse.step
   $permissions['chasse']['getstats'] = $chasseAccessPermissions;

--- a/chasse.php
+++ b/chasse.php
@@ -205,7 +205,7 @@ function chasse_civicrm_alterAPIPermissions($entity, $action, &$params, &$permis
 
   $chasseAccessPermissions = ['edit message templates'];
 
-  // Allow users with 'edit message templates' to read+write access to Chassé settings.
+  // Allow users with 'edit message templates' read+write access to Chassé settings.
 
   if ($entity === 'setting') {
 

--- a/chasse.php
+++ b/chasse.php
@@ -205,10 +205,19 @@ function chasse_civicrm_alterAPIPermissions($entity, $action, &$params, &$permis
 
   $chasseAccessPermissions = ['edit message templates'];
 
-  // Allow users with 'edit message templates' full access to Chassé settings.
-  if ($entity === 'Setting' && (($params['select'] ?? '') === 'chasse_config')) {
-    // Grant full access to this setting.
-    $permissions['setting']['default'] = $chasseAccessPermissions;
+  // Allow users with 'edit message templates' to read+write access to Chassé settings.
+
+  if ($entity === 'setting') {
+
+    if (($params['name'] ?? '') === 'chasse_config') {
+      $permissions['setting']['getvalue'] = $chasseAccessPermissions;
+    }
+
+    // Check 'chasse_config' is the *only* setting to "create" in the parameters for the api call before granting access.
+    if (! array_diff ( array_keys($params), array( 'chasse_config', 'check_permissions', 'prettyprint', 'version' ) ) ) {
+      $permissions['setting']['create'] = $chasseAccessPermissions;
+    }
+
   }
 
   // Allow users witih 'edit message templates' to call:


### PR DESCRIPTION
Hi @artfulrobot ,

Sorry it took me a while to test your edits to PR ─ and I'm afraid they don't seem to work for me 

I don't think it's possible to allow "full" access to a given setting just by checking the 'name' parameter, because the 'create' call to save the settings doesn't take a 'name' parameter.

So non-admin user couldn't save new journeys.

Instead I think we need to that chasse_config is a key in the parameter array.

My initial PR did this, but didn't check it was the *only* key, which seemed open to abuse if you could save two settings at the same time. This updated version attempts to do this more tightly. 

It seems a little bit "hacky" to me, but can't see any other approach that will work inside the current api interface / alterAPIPermissions hook. (Don't know if there is some design reason why it has to be like this? Feels like a limitation baked of the api interface design IMHO!)