### PR TITLE
Fix how permissions are granted to chasse_config setting

### DIFF
--- a/chasse.php
+++ b/chasse.php
@@ -214,7 +214,7 @@ function chasse_civicrm_alterAPIPermissions($entity, $action, &$params, &$permis
     }
 
     // Check 'chasse_config' is the *only* setting to "create" in the parameters for the api call before granting access.
-    if (! array_diff ( array_keys($params), array( 'chasse_config', 'check_permissions', 'prettyprint', 'version' ) ) ) {
+    if (array_diff ( array_keys($params), ['check_permissions', 'prettyprint', 'version'] ) === ['chasse_config'] ) {
       $permissions['setting']['create'] = $chasseAccessPermissions;
     }
 

--- a/chasse.php
+++ b/chasse.php
@@ -220,7 +220,7 @@ function chasse_civicrm_alterAPIPermissions($entity, $action, &$params, &$permis
 
   }
 
-  // Allow users witih 'edit message templates' to call:
+  // Allow users with 'edit message templates' to call:
   // - Chasse.getstats
   // - Chasse.step
   $permissions['chasse']['getstats'] = $chasseAccessPermissions;

--- a/chasse.php
+++ b/chasse.php
@@ -205,7 +205,7 @@ function chasse_civicrm_alterAPIPermissions($entity, $action, &$params, &$permis
 
   $chasseAccessPermissions = ['edit message templates'];
 
-  // Allow users with 'edit message templates' to read+write access to Chassé settings.
+  // Allow users with 'edit message templates' read+write access to Chassé settings.
 
   if ($entity === 'setting') {
 

--- a/chasse.php
+++ b/chasse.php
@@ -205,10 +205,19 @@ function chasse_civicrm_alterAPIPermissions($entity, $action, &$params, &$permis
 
   $chasseAccessPermissions = ['edit message templates'];
 
-  // Allow users with 'edit message templates' full access to Chassé settings.
-  if ($entity === 'Setting' && (($params['select'] ?? '') === 'chasse_config')) {
-    // Grant full access to this setting.
-    $permissions['setting']['default'] = $chasseAccessPermissions;
+  // Allow users with 'edit message templates' to read+write access to Chassé settings.
+
+  if ($entity === 'setting') {
+
+    if (($params['name'] ?? '') === 'chasse_config') {
+      $permissions['setting']['getvalue'] = $chasseAccessPermissions;
+    }
+
+    // Check 'chasse_config' is the *only* setting to "create" in the parameters for the api call before granting access.
+    if (! array_diff ( array_keys($params), array( 'chasse_config', 'check_permissions', 'prettyprint', 'version' ) ) ) {
+      $permissions['setting']['create'] = $chasseAccessPermissions;
+    }
+
   }
 
   // Allow users witih 'edit message templates' to call:


### PR DESCRIPTION
This PR ensures that user is only granted access for a Setting.Create API call if their request **only** edits the chasse_config setting.