### PR TITLE
Fix license link.

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -29,7 +29,7 @@ The system can be **automated** so that people bump along without you clicking a
 ## Free/Libre Software
 
 This extension is written by [Artful Robot](https://artfulrobot.uk/) and
-licensed under [AGPL-3.0](LICENSE.txt). It's hosted at
+licensed under [AGPL-3.0](https://www.gnu.org/licenses/agpl-3.0.html). It's hosted at
 [github](https://github.com/artfulrobot/chasse), please use that for reporting
 issues and pull/merge requests from developers are welcome. Developers: pease
 see the [technical information](/developer) to help you understand how it works.


### PR DESCRIPTION
Can't link outside the `docs` tree any longer.